### PR TITLE
Fix wrong relative paths in subninjas and fix tests

### DIFF
--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -133,7 +133,8 @@ class Helper(unittest.TestCase):
 		if os.path.exists(path):
 			current_cwd = os.getcwd()
 			os.chdir(self.build_dir)
-			subprocess.check_call([os.path.relpath(path, self.build_dir)])
+			executable = os.path.relpath(path, self.build_dir)
+			subprocess.check_call([executable], env={'LD_LIBRARY_PATH': os.path.dirname(executable)})
 			os.chdir(current_cwd)
 		elif os.path.exists(path + ".exe"):
 			subprocess.check_call([path + ".exe"])
@@ -200,8 +201,8 @@ class TestStaticLib(Helper):
 	def test_withapp(self):
 		self.enter_test("static_lib/withapp")
 		self.check_basics("build/bin_debug/ninjatestprj_app", "build/bin_release/ninjatestprj_app")
-		self.out_exist("build/bin_debug/ninjatestprj_lib test1")
-		self.out_exist("build/bin_release/ninjatestprj_lib test1")
+		self.out_exist("build/bin_debug/ninjatestprj_lib_test1")
+		self.out_exist("build/bin_release/ninjatestprj_lib_test1")
 		self.out_exist("build/bin_debug/ninjatestprj_lib_test2")
 		self.out_exist("build/bin_release/ninjatestprj_lib_test2")
 		self.exit_test()

--- a/tests/static_lib/withapp/premake5.lua
+++ b/tests/static_lib/withapp/premake5.lua
@@ -12,7 +12,7 @@ project "ninjatestprj_app"
 
 	files {"main.cpp"}
 	includedirs {"test1", "test2"}
-	links {"ninjatestprj_lib test1", "ninjatestprj_lib_test2"}
+	links {"ninjatestprj_lib_test1", "ninjatestprj_lib_test2"}
 
 	configuration "windows"
 		links { "user32", "gdi32" }
@@ -29,7 +29,7 @@ project "ninjatestprj_app"
 		defines {"NDEBUG"}
 		optimize "On"
 
-project "ninjatestprj_lib test1"
+project "ninjatestprj_lib_test1"
 	kind "StaticLib"
 	location "build"
 	language "C++"


### PR DESCRIPTION
When projects have a different location than the workspace, it breaks ninja as the relative paths in the subninjas are relative to the subninja and not the build directory (https://github.com/ninja-build/ninja/issues/977).

Also, some tests were broken (at least on Linux).

If you prefer to split it to 2 pull requests, let me know.

Not tested on non-Linux setups.