### PR TITLE
fix for `targetextension` config option

### DIFF
--- a/ninja.lua
+++ b/ninja.lua
@@ -1,4 +1,4 @@
-﻿--
+--
 -- Name:        premake-ninja/ninja.lua
 -- Purpose:     Define the ninja action.
 -- Author:      Dmitry Ivanov
@@ -635,7 +635,7 @@ function ninja.generateProjectCfg(cfg)
 		p.w("# link shared lib")
 
 		local extra_outputs = {}
-		if ninja.endsWith(output, ".dll") then
+		if ninja.endsWith(output, ".dll") or toolset == p.tools.msc then
 			extra_outputs = { ninja.noext(output, ".dll") .. ".lib", ninja.noext(output, ".dll") .. ".exp" }
 		elseif ninja.endsWith(output, ".so") then
 			-- in case of .so there are no corresponding .a file


### PR DESCRIPTION
With Premake you can specify the option to change target file's extension like this: `targetextension ".aes"`

This would cause the check I fixed to fail, as the extension isn't `.dll`. Not sure if my fix for this is perfect, but I don't think MSVC can build non-Windows libraries, so it should be fine?

This fails the gcc test though, but honestly I don't have any better ideas for now. But for now better to partially fix than not at all, unless you have any better ideas...