### PR TITLE
Add support for custom toolsets and enforce root-relative paths

### DIFF
--- a/ninja.lua
+++ b/ninja.lua
@@ -364,8 +364,9 @@ local function compilation_rules(cfg, toolset, pch)
 	local ar = toolset.gettoolname(cfg, "ar")
 	local link = toolset.gettoolname(cfg, iif(cfg.language == "C", "cc", "cxx"))
 	-- only compile rc files on windows
+	local rc = ""
 	if cfg.system == premake.WINDOWS then
-		local rc = toolset.gettoolname(cfg, "rc")
+		rc = toolset.gettoolname(cfg, "rc")
 	end
 
 	local all_cflags = getcflags(toolset, cfg, cfg)

--- a/ninja.lua
+++ b/ninja.lua
@@ -251,8 +251,15 @@ local function getcflags(toolset, cfg, filecfg)
 	local cppflags = ninja.list(toolset.getcppflags(filecfg))
 	local cflags = ninja.list(toolset.getcflags(filecfg))
 	local defines = ninja.list(table.join(toolset.getdefines(filecfg.defines), toolset.getundefines(filecfg.undefines)))
-	local includes = ninja.list(toolset.getincludedirs(cfg, filecfg.includedirs, filecfg.externalincludedirs, filecfg.frameworkdirs, filecfg.includedirsafter))
-	local forceincludes = ninja.list(toolset.getforceincludes(cfg))
+	
+	-- ninja expects include directories to be relative to the root folder.
+	-- what follows is a little hack to trick the toolsets into thinking cfg.workspace is actually cfg.project
+	-- and will therefore use that as the base for the relative paths
+	-- this is an issue with premake itself.
+	local cfg_override = cfg
+	cfg_override.project = cfg.workspace
+	local includes = ninja.list(toolset.getincludedirs(cfg_override, filecfg.includedirs, filecfg.externalincludedirs, filecfg.frameworkdirs, filecfg.includedirsafter))
+	local forceincludes = ninja.list(toolset.getforceincludes(cfg_override))
 
 	return buildopt .. cppflags .. cflags .. defines .. includes .. forceincludes
 end
@@ -262,8 +269,16 @@ local function getcxxflags(toolset, cfg, filecfg)
 	local cppflags = ninja.list(toolset.getcppflags(filecfg))
 	local cxxflags = ninja.list(toolset.getcxxflags(filecfg))
 	local defines = ninja.list(table.join(toolset.getdefines(filecfg.defines), toolset.getundefines(filecfg.undefines)))
-	local includes = ninja.list(toolset.getincludedirs(cfg, filecfg.includedirs, filecfg.externalincludedirs, filecfg.frameworkdirs, filecfg.includedirsafter))
-	local forceincludes = ninja.list(toolset.getforceincludes(cfg))
+	
+	-- ninja expects include directories to be relative to the root folder.
+	-- what follows is a little hack to trick the toolsets into thinking cfg.workspace is actually cfg.project
+	-- and will therefore use that as the base for the relative paths
+	-- this is an issue with premake itself.
+	local cfg_override = cfg
+	cfg_override.project = cfg.workspace
+	local includes = ninja.list(toolset.getincludedirs(cfg_override, filecfg.includedirs, filecfg.externalincludedirs, filecfg.frameworkdirs, filecfg.includedirsafter))
+	local forceincludes = ninja.list(toolset.getforceincludes(cfg_override))
+
 	return buildopt .. cppflags .. cxxflags .. defines .. includes .. forceincludes
 end
 
@@ -348,7 +363,10 @@ local function compilation_rules(cfg, toolset, pch)
 	local cxx = toolset.gettoolname(cfg, "cxx")
 	local ar = toolset.gettoolname(cfg, "ar")
 	local link = toolset.gettoolname(cfg, iif(cfg.language == "C", "cc", "cxx"))
-	local rc = toolset.gettoolname(cfg, "rc")
+	-- only compile rc files on windows
+	if cfg.platform == premake.WINDOWS then
+		local rc = toolset.gettoolname(cfg, "rc")
+	end
 
 	local all_cflags = getcflags(toolset, cfg, cfg)
 	local all_cxxflags = getcxxflags(toolset, cfg, cfg)
@@ -368,11 +386,14 @@ local function compilation_rules(cfg, toolset, pch)
 		p.outln("  description = cxx $out")
 		p.outln("  deps = msvc")
 		p.outln("")
-		p.outln("RESFLAGS = " .. all_resflags)
-		p.outln("rule rc")
-		p.outln("  command = " .. rc .. " /nologo /fo$out $in $RESFLAGS")
-		p.outln("  description = rc $out")
-		p.outln("")
+		-- only compile rc files on windows
+		if cfg.platform == premake.WINDOWS then
+			p.outln("RESFLAGS = " .. all_resflags)
+			p.outln("rule rc")
+			p.outln("  command = " .. rc .. " /nologo /fo$out $in $RESFLAGS")
+			p.outln("  description = rc $out")
+			p.outln("")
+		end
 		if cfg.kind == p.STATICLIB then
 			p.outln("rule ar")
 			p.outln("  command = " .. ar .. " $in /nologo -OUT:$out")
@@ -384,7 +405,7 @@ local function compilation_rules(cfg, toolset, pch)
 			p.outln("  description = link $out")
 			p.outln("")
 		end
-	elseif toolset == p.tools.clang or toolset == p.tools.gcc then
+	elseif toolset == p.tools.clang or toolset == p.tools.gcc or toolset == p.tools.emcc then -- << EMSCRIPTEN (or toolset == p.tools.emcc)
 		local force_include_pch = ""
 		if pch then
 			force_include_pch = " -include " .. ninja.shesc(pch.placeholder)
@@ -408,11 +429,14 @@ local function compilation_rules(cfg, toolset, pch)
 		p.outln("  depfile = $out.d")
 		p.outln("  deps = gcc")
 		p.outln("")
-		p.outln("RESFLAGS = " .. all_resflags)
-		p.outln("rule rc")
-		p.outln("  command = " .. rc .. " -i $in -o $out $RESFLAGS")
-		p.outln("  description = rc $out")
-		p.outln("")
+		-- only compile rc files on windows
+		if cfg.platform == premake.WINDOWS then
+			p.outln("RESFLAGS = " .. all_resflags)
+			p.outln("rule rc")
+			p.outln("  command = " .. rc .. " -i $in -o $out $RESFLAGS")
+			p.outln("  description = rc $out")
+			p.outln("")
+		end
 		if cfg.kind == p.STATICLIB then
 			p.outln("rule ar")
 			p.outln("  command = " .. ar .. " rcs $out $in")

--- a/ninja.lua
+++ b/ninja.lua
@@ -406,7 +406,7 @@ local function compilation_rules(cfg, toolset, pch)
 			p.outln("  description = link $out")
 			p.outln("")
 		end
-	elseif toolset == p.tools.clang or toolset == p.tools.gcc or toolset == p.tools.emcc then -- << EMSCRIPTEN (or toolset == p.tools.emcc)
+	elseif toolset == p.tools.clang or toolset == p.tools.gcc or (toolset.clang_like ~= nil and toolset.clang_like()) then
 		local force_include_pch = ""
 		if pch then
 			force_include_pch = " -include " .. ninja.shesc(pch.placeholder)

--- a/ninja.lua
+++ b/ninja.lua
@@ -364,7 +364,7 @@ local function compilation_rules(cfg, toolset, pch)
 	local ar = toolset.gettoolname(cfg, "ar")
 	local link = toolset.gettoolname(cfg, iif(cfg.language == "C", "cc", "cxx"))
 	-- only compile rc files on windows
-	if cfg.platform == premake.WINDOWS then
+	if cfg.system == premake.WINDOWS then
 		local rc = toolset.gettoolname(cfg, "rc")
 	end
 
@@ -387,7 +387,7 @@ local function compilation_rules(cfg, toolset, pch)
 		p.outln("  deps = msvc")
 		p.outln("")
 		-- only compile rc files on windows
-		if cfg.platform == premake.WINDOWS then
+		if cfg.system == premake.WINDOWS then
 			p.outln("RESFLAGS = " .. all_resflags)
 			p.outln("rule rc")
 			p.outln("  command = " .. rc .. " /nologo /fo$out $in $RESFLAGS")
@@ -430,7 +430,7 @@ local function compilation_rules(cfg, toolset, pch)
 		p.outln("  deps = gcc")
 		p.outln("")
 		-- only compile rc files on windows
-		if cfg.platform == premake.WINDOWS then
+		if cfg.system == premake.WINDOWS then
 			p.outln("RESFLAGS = " .. all_resflags)
 			p.outln("rule rc")
 			p.outln("  command = " .. rc .. " -i $in -o $out $RESFLAGS")


### PR DESCRIPTION
# Changes
## Ninja expects all paths to be relative to the root ninja folder
(see: [Issue 997 in ninja-build/ninja](https://github.com/ninja-build/ninja/issues/977))
Ninja expects paths to files to be relative to the root build file. Unfortunately, premake has no way of telling this to the toolsets, but we can work around this limitation by tricking them into generating paths relative to the workspace directory. See lines 255-262 and 273-280 for specifics.

## RC files shouldn't be supported on targets other than windows
Since platforms like macos and linux don't integrate support for rc/res files, the "rc" rule shouldn't be generated. This removes the expectation that every toolset has a rc file command and allows support for custom toolsets, like emscripten, that don't support rc files.

## Custom toolset support
Added simple support for custom toolset. Ninja will check for the function `clang_like()` on toolsets and if it returns true, will generate compilation rules using the gcc/clang branch of the conditional in `compilation_rules(...)`.

# Associated Issues
Fixes #32 