### PR TITLE
Fix for pre,post,prelink commands , relative includes  and other fixes to make it more similar to how premake gmake2 works.

### DIFF
--- a/ninja.lua
+++ b/ninja.lua
@@ -323,46 +323,17 @@ local function getresflags(toolset, cfg, filecfg)
 	return defines .. includes .. options
 end
 
-local function fixupbuildcommands(cfg,commands)
-
-	local function splitstring(inputstr, sep)
-		if sep == nil then
-			sep = "%s"
-		end
-		local t = {}
-		for str in string.gmatch(inputstr, "([^"..sep.."]+)") do
-			table.insert(t, str)
-		end
-		return t
+local function fixupbuildcommands(cfg, commands)
+	if cfg.workspace.location == cfg.project.location then
+		return commands
 	end
+	local relative = path.getrelative(cfg.workspace.location, cfg.project.location)
+	
+	local newcommands = { "cd " .. relative }
 
-	local newcommands = {}
-	for _,Item in ipairs(commands) do
-
-		local splits = splitstring(Item," ")
-		local newvalue = ""
-
-
-		for ind,item in ipairs(splits) do
-			local ispath = string.find(item,"/") or string.find(item,"\\")
-
-			if ispath then
-				local relative = path.getrelative(cfg.workspace.location,cfg.project.location)
-				newvalue = newvalue .. relative .. "/" .. item
-			else
-				newvalue = newvalue .. item
-			end
-
-			if ind ~= #splits then
-				newvalue = newvalue .. " "
-			end
-
-		end
-
-		table.insert(newcommands,newvalue)
+	for _, Item in ipairs(commands) do
+		table.insert(newcommands, Item)
 	end
-
-
 	return newcommands
 end
 local function prebuild_rule(cfg)

--- a/ninja.lua
+++ b/ninja.lua
@@ -250,7 +250,11 @@ local function getFileDependencies(cfg)
 		dependencies = {"prebuild_" .. get_key(cfg)}
 	end
 	for i = 1, #cfg.dependson do
-		table.insert(dependencies, cfg.dependson[i] .. "_" .. cfg.buildcfg .. "_" .. cfg.platform)
+		local dependposfix = cfg.buildcfg
+		if cfg.platform then
+			dependposfix = dependposfix .. "_" .. cfg.platform
+		end
+		table.insert(dependencies, cfg.dependson[i] .. "_" .. dependposfix)
 	end
 	return dependencies
 end

--- a/ninja.lua
+++ b/ninja.lua
@@ -334,7 +334,7 @@ local function fixupbuildcommands(cfg,commands)
 		local newvalue = ""
 
 
-		for _,item in ipairs(splits) do
+		for ind,item in ipairs(splits) do
 			local ispath = string.find(item,"/") or string.find(item,"\\")
 
 			if ispath then
@@ -343,6 +343,11 @@ local function fixupbuildcommands(cfg,commands)
 			else
 				newvalue = newvalue .. item
 			end
+
+			if ind ~= #splits then
+				newvalue = newvalue .. " "
+			end
+
 		end
 
 		table.insert(newcommands,newvalue)

--- a/ninja.lua
+++ b/ninja.lua
@@ -244,11 +244,7 @@ local function shouldcompileascpp(filecfg)
 	return path.iscppfile(filecfg.abspath)
 end
 
-local function getFileDependencies(cfg)
-	local dependencies = {}
-	if #cfg.prebuildcommands > 0 or cfg.prebuildmessage then
-		dependencies = {"prebuild_" .. get_key(cfg)}
-	end
+local function addcfgDependencies(dependencies,cfg)
 	for i = 1, #cfg.dependson do
 		local dependposfix = cfg.buildcfg
 		if cfg.platform then
@@ -256,6 +252,19 @@ local function getFileDependencies(cfg)
 		end
 		table.insert(dependencies, cfg.dependson[i] .. "_" .. dependposfix)
 	end
+end
+
+local function getcfgDependencies(cfg)
+	local dependencies = {}
+	addcfgDependencies(dependencies,cfg)
+	return dependencies
+end
+local function getFileDependencies(cfg)
+	local dependencies = {}
+	if #cfg.prebuildcommands > 0 or cfg.prebuildmessage then
+		dependencies = {"prebuild_" .. get_key(cfg)}
+	end
+	addcfgDependencies(dependencies,cfg)
 	return dependencies
 end
 
@@ -758,7 +767,7 @@ function ninja.generateProjectCfg(cfg)
 	---------------------------------------------------- build final target
 	if #cfg.prebuildcommands > 0 or cfg.prebuildmessage then
 		p.outln("# prebuild")
-		add_build(cfg, "prebuild_" .. get_key(cfg), {}, "run_prebuild", {}, {}, {}, {})
+		add_build(cfg, "prebuild_" .. get_key(cfg), {}, "run_prebuild", {}, {}, getcfgDependencies(cfg), {})
 	end
 	local prelink_dependency = {}
 	if #cfg.prelinkcommands > 0 or cfg.prelinkmessage then

--- a/ninja.lua
+++ b/ninja.lua
@@ -160,14 +160,23 @@ function ninja.generateWorkspace(wks)
 				table.insert(cfgs[cfg.buildcfg], key)
 
 				-- set first configuration name
-				if (cfg_first == nil) and (cfg.kind == p.CONSOLEAPP or cfg.kind == p.WINDOWEDAPP) then
-					cfg_first = key
+				if wks.defaultplatform == "" then 
+					if (cfg_first == nil) and (cfg.kind == p.CONSOLEAPP or cfg.kind == p.WINDOWEDAPP) then
+						cfg_first = key
+					end
 				end
 				if (cfg_first_lib == nil) and (cfg.kind == p.STATICLIB or cfg.kind == p.SHAREDLIB) then
 					cfg_first_lib = key
 				end
-				if prj.name == wks.startproject then
+
+				if wks.defaultplatform == "" then 
 					cfg_first = key
+				elseif prj.name == wks.startproject then
+					if cfg.platform == wks.defaultplatform then
+						if cfg_first == nil then
+							cfg_first = key
+						end
+					end
 				end
 
 				-- include other ninja file

--- a/ninja.lua
+++ b/ninja.lua
@@ -328,7 +328,7 @@ local function fixupbuildcommands(cfg,commands)
 	end
 
 	local newcommands = {}
-	for _,Item in ipairs(cfg.prebuildcommands) do
+	for _,Item in ipairs(commands) do
 
 		local splits = splitstring(Item," ")
 		local newvalue = ""
@@ -345,7 +345,7 @@ local function fixupbuildcommands(cfg,commands)
 			end
 		end
 
-		table.insert(newcommands,newinput)
+		table.insert(newcommands,newvalue)
 	end
 
 

--- a/ninja.lua
+++ b/ninja.lua
@@ -250,7 +250,7 @@ local function getFileDependencies(cfg)
 		dependencies = {"prebuild_" .. get_key(cfg)}
 	end
 	for i = 1, #cfg.dependson do
-		table.insert(dependencies, cfg.dependson[i] .. "_" .. cfg.buildcfg)
+		table.insert(dependencies, cfg.dependson[i] .. "_" .. cfg.buildcfg .. "_" .. cfg.platform)
 	end
 	return dependencies
 end

--- a/ninja.lua
+++ b/ninja.lua
@@ -263,10 +263,6 @@ end
 local function fixincludedir(cfg,includedirs)
 	local fixincludedirs = {}
 	for _,value in ipairs(includedirs) do
-		if value == cfg.project.location then -- the '.' this would make would not work as the working directory would not change.
-			value = path.getrelative(cfg.workspace.location,cfg.project.location)
-		end
-
 		local newvalue = path.getrelative(cfg.workspace.location, value)
 
 		table.insert(fixincludedirs,newvalue)


### PR DESCRIPTION
- Fixed defualtplatform not using defualtplatform when set.
- Fixed prebuild commands runing even when its project dependencies are not built. 
- Fixed project c and c++ includes not being relative to the [location](https://premake.github.io/docs/location/) property.
- Fixed project pre,post,prelink not runing in the working working directory of [location](https://premake.github.io/docs/location/) property.


I havent updated forceincludes because i didn't use them in project and this pull request is a bit messy.I will fix it after this pull request. 