### PR TITLE
fixed missing prefix in getFileDependencies

### DIFF
--- a/ninja.lua
+++ b/ninja.lua
@@ -241,7 +241,13 @@ local function getFileDependencies(cfg)
 		dependencies = {"prebuild_" .. get_key(cfg)}
 	end
 	for i = 1, #cfg.dependson do
-		table.insert(dependencies, cfg.dependson[i] .. "_" .. cfg.buildcfg)
+
+		local dependposfix = ""
+		if cfg.platform then
+			dependposfix = "_" .. cfg.platform
+		end
+
+		table.insert(dependencies, cfg.dependson[i] .. "_" .. cfg.buildcfg .. dependposfix)
 	end
 	return dependencies
 end

--- a/ninja.lua
+++ b/ninja.lua
@@ -242,12 +242,12 @@ local function getFileDependencies(cfg)
 	end
 	for i = 1, #cfg.dependson do
 
-		local dependposfix = ""
+		local dependpostfix = ""
 		if cfg.platform then
-			dependposfix = "_" .. cfg.platform
+			dependpostfix = "_" .. cfg.platform
 		end
 
-		table.insert(dependencies, cfg.dependson[i] .. "_" .. cfg.buildcfg .. dependposfix)
+		table.insert(dependencies, cfg.dependson[i] .. "_" .. cfg.buildcfg .. dependpostfix)
 	end
 	return dependencies
 end


### PR DESCRIPTION
this pull request fixes the issue of getFileDependencies not haveing the correct dependency as the
 function get_key on 32 on ninja.lua adds the prefix if cfg.platform is set as seen below
```lua
local function get_key(cfg, name)
	local name = name or cfg.project.name

	if cfg.platform then
		return name .. "_" .. cfg.buildcfg .. "_" .. cfg.platform
	else
		return name .. "_" .. cfg.buildcfg
	end
end
```
while getFileDependencies did have this prefix breaking some projects. while gmake2 would build them just fine.