### PR TITLE
Remove build prefix from generated Ninja files.

### DIFF
--- a/ninja.lua
+++ b/ninja.lua
@@ -810,7 +810,7 @@ function ninja.projectCfgFilename(cfg, relative)
 	else
 		relative = ""
 	end
-	return relative .. "build_" .. get_key(cfg, cfg.project.filename) .. ".ninja"
+	return relative .. get_key(cfg, cfg.project.filename) .. ".ninja"
 end
 
 -- check if string starts with string


### PR DESCRIPTION
As title says, I find this prefix just clutters the build folder and doesn't much value.

What do you think?