### PR TITLE
Add option to generate all paths relative to root.

### DIFF
--- a/ninja.lua
+++ b/ninja.lua
@@ -666,8 +666,8 @@ function ninja.generateProjectCfg(cfg)
 	local is_c_or_cpp = cfg.language == p.C or cfg.language == p.CPP;
 
 	---------------------------------------------------- figure out settings
+	local pch = nil
 	if is_c_or_cpp then
-		local pch = nil
 		if toolset ~= p.tools.msc then
 			pch = p.tools.gcc.getpch(cfg)
 			if pch then


### PR DESCRIPTION
Depends on: https://github.com/jimon/premake-ninja/pull/46

See only https://github.com/jimon/premake-ninja/commit/8dad225dc9531ed91876ad703d9534eb9354b98f for review.

Add option to generate all paths relative to root. This adds a new generation mode that keeps all paths relative to the
root script dir.

This forces GCC to write paths in diagnostics relative to the root script, which allows VS Code to recognize the paths when ctrl-clicking the paths in compiler diagnostics in terminal.

Without this, we get path relative to the build folder, `../../foo.c`, which VS Code cannot recognize and hinders instant code navigation.